### PR TITLE
fixes issue #78 by replacing st_crs(sf_obj)$input with st_crs(sf_obj)$proj4string

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aniMotum
 Title: Fit Continuous-Time State-Space and Latent Variable Models for Quality Control of Argos Satellite (and Other) Telemetry Data and for Estimating Changes in Animal Movement
-Version: 1.2-11.9022
+Version: 1.2-11
 Date: 2025-05-15
 Authors@R: 
     c(

--- a/R/pf_sf_project.R
+++ b/R/pf_sf_project.R
@@ -38,7 +38,7 @@ pf_sf_project <- function(x) {
       coords <- c("x", "y")
       sf_locs <- st_as_sf(x, coords = coords, 
                           crs = st_crs("+proj=merc +units=m +datum=WGS84 +no_defs"))
-      prj <- st_crs(sf_locs)$input
+      prj <- st_crs(sf_locs)$proj4string
       sf_locs <- st_transform(sf_locs, sub("units=m", "units=km", prj, fixed = TRUE))
     }
     
@@ -48,7 +48,7 @@ pf_sf_project <- function(x) {
     if(st_is_longlat(x)) {
       prj <- "+proj=merc +lon_0=0 +datum=WGS84 +units=km +no_defs"
     } else {
-      prj <- st_crs(x)$input  
+      prj <- st_crs(x)$proj4string  
     }
   
     # if data CRS units are m then change to km, otherwise optimiser may choke


### PR DESCRIPTION
As mentioned in #78, `sf::st_crs(sf_ob)$input` does not reliably return
units information (e.g. if the CRS is specified
with an EPSG code).

With this PR, the following will return predictions in 'km' units

```r
ellie_sf <- ellie |> 
sf::st_as_sf(coords = c("lon","lat"), crs = 4326) |> 
sf::st_transform(3031)

st_crs(ellie_sf)$input

fit <-
  fit_ssm(
    x = ellie_sf,
    model = "rw",
    time.step = 24
  )

st_crs(fit$ssm[[1]]$predicted)$proj4string
```